### PR TITLE
Update context.tf for proper Terraform 14 support

### DIFF
--- a/context.tf
+++ b/context.tf
@@ -18,8 +18,10 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
+
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.22.0" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace


### PR DESCRIPTION


## what

This PR replaces `context.tf` with the latest version from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf. That version provides proper support for Terraform 14.

## why

As it is now, this module pulls terraform-null-label 0.19.2, which sets `required_version` for Terraform to `>= 0.12.0, < 0.14.0`. Terraform 14 is therefore not supported.