### PR TITLE
Updated readme to use the correct module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Here's how to invoke this example module in your projects
 
 ```hcl
 module "kafka" {
-  source = "cloudposse/apache-kafka-cluster/aws"
+  source = "cloudposse/msk-apache-kafka-cluster/aws"
   # Cloud Posse recommends pinning every module to a specific version
   # version = "x.x.x"
 


### PR DESCRIPTION
## what
* The snippet contains the wrong name of the module resulting in TF being unable to find it in the registry. I've changed it to reflect the name in the registry: https://registry.terraform.io/modules/cloudposse/msk-apache-kafka-cluster/aws/latest

## why
* Terraform cannot find the module in the registry due to a name mismatch

## references
* This closes #31 

