### PR TITLE
fix output of comma separated list of brokers in hostname output

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Available targets:
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | MSK Cluster name |
 | <a name="output_config_arn"></a> [config\_arn](#output\_config\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_current_version"></a> [current\_version](#output\_current\_version) | Current version of the MSK Cluster used for updates |
-| <a name="output_hostname"></a> [hostname](#output\_hostname) | MSK Cluster Broker DNS hostname |
+| <a name="output_hostname"></a> [hostname](#output\_hostname) | Comma separated list of one or more MSK Cluster Broker DNS hostname |
 | <a name="output_latest_revision"></a> [latest\_revision](#output\_latest\_revision) | Latest revision of the configuration |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group rule |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group rule |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -96,7 +96,7 @@
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | MSK Cluster name |
 | <a name="output_config_arn"></a> [config\_arn](#output\_config\_arn) | Amazon Resource Name (ARN) of the configuration |
 | <a name="output_current_version"></a> [current\_version](#output\_current\_version) | Current version of the MSK Cluster used for updates |
-| <a name="output_hostname"></a> [hostname](#output\_hostname) | MSK Cluster Broker DNS hostname |
+| <a name="output_hostname"></a> [hostname](#output\_hostname) | Comma separated list of one or more MSK Cluster Broker DNS hostname |
 | <a name="output_latest_revision"></a> [latest\_revision](#output\_latest\_revision) | Latest revision of the configuration |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group rule |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group rule |

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,8 +44,8 @@ output "latest_revision" {
 }
 
 output "hostname" {
-  description = "MSK Cluster Broker DNS hostname"
-  value       = join("", module.hostname.*.hostname)
+  description = "Comma separated list of one or more MSK Cluster Broker DNS hostname"
+  value       = join(",", module.hostname.*.hostname)
 }
 
 output "cluster_name" {


### PR DESCRIPTION
## what
fix output of comma separated list of brokers in hostname output

## why
because its not usable

## references
* https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/issues/23

