### PR TITLE
Fix: fix incorrect attribute being supplied to `route53-cluster-hostname` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Hugo Samayoa][htplbc_avatar]][htplbc_homepage]<br/>[Hugo Samayoa][htplbc_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
-|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Hugo Samayoa][htplbc_avatar]][htplbc_homepage]<br/>[Hugo Samayoa][htplbc_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
+|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
@@ -421,6 +421,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [htplbc_avatar]: https://img.cloudposse.com/150x150/https://github.com/htplbc.png
   [nitrocode_homepage]: https://github.com/nitrocode
   [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
+  [korenyoni_homepage]: https://github.com/korenyoni
+  [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -109,3 +109,5 @@ contributors:
     github: "htplbc"
   - name: "RB"
     github: "nitrocode"
+  - name: "Yonatan Koren"
+    github: "korenyoni"

--- a/main.tf
+++ b/main.tf
@@ -167,10 +167,10 @@ module "hostname" {
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"
 
-  enabled = module.this.enabled && length(var.zone_id) > 0
-  name    = "${module.this.name}-broker-${count.index + 1}"
-  zone_id = var.zone_id
-  records = [split(":", element(local.bootstrap_brokers_combined_list, count.index))[0]]
+  enabled  = module.this.enabled && length(var.zone_id) > 0
+  dns_name = "${module.this.name}-broker-${count.index + 1}"
+  zone_id  = var.zone_id
+  records  = [split(":", element(local.bootstrap_brokers_combined_list, count.index))[0]]
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Fix incorrect variable being supplied to `route53-cluster-hostname` module.

## why
* `name` is passed instead of `dns_name` to `route53-cluster-hostname`. The `route53-cluster-hostname` module has `var.name` due to `context.tf`, however it does not reference `var.name` in any place.

https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/blob/d485ab695a4bc30573c8be3da8d8c868c5f1bcb6/main.tf#L3

```hcl
resource "aws_route53_record" "default" {
  count   = module.this.enabled ? 1 : 0
  name    = var.dns_name == "" ? module.this.id : var.dns_name # dns_name is consolidated, not name, when setting the route53 record name 
  zone_id = var.zone_id
  type    = var.type
  ttl     = var.ttl
  records = var.records
}
```

## references
* N/A

