### PR TITLE
Fix enabling IAM and SCRAM authentication at the same time

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,8 @@ resource "aws_msk_cluster" "default" {
         }
       }
       dynamic "sasl" {
+        #bridgecrew:skip=BC_AWS_LOGGING_18:Skipping `Amazon MSK cluster logging is not enabled` check since it can be enabled with cloudwatch_logs_enabled = true
+        #bridgecrew:skip=BC_AWS_GENERAL_32:Skipping `MSK cluster encryption at rest and in transit is not enabled` check since it can be enabled with encryption_in_cluster = true
         for_each = var.client_sasl_scram_enabled || var.client_sasl_iam_enabled ? [1] : []
         content {
           scram = var.client_sasl_scram_enabled


### PR DESCRIPTION
## what
* As a MSK user, I would like to enable both IAM and SCRAM authentication for the brokers at the same time.

## why
* When enabling both `client_sasl_iam_enabled` and `client_sasl_scram_enabled` an `Error: Too many sasl blocks` is being produced.

## references
closes #42


