### PR TITLE
Fix Broker Hostname Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Available targets:
 | [aws_msk_cluster.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_configuration) | resource |
 | [aws_msk_scram_secret_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_scram_secret_association) | resource |
+| [aws_msk_broker_nodes.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/msk_broker_nodes) | data source |
 
 ## Inputs
 
@@ -247,10 +248,11 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bootstrap_broker_tls"></a> [bootstrap\_broker\_tls](#output\_bootstrap\_broker\_tls) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster |
+| <a name="output_all_brokers"></a> [all\_brokers](#output\_all\_brokers) | A list of all brokers |
 | <a name="output_bootstrap_brokers"></a> [bootstrap\_brokers](#output\_bootstrap\_brokers) | A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster |
 | <a name="output_bootstrap_brokers_iam"></a> [bootstrap\_brokers\_iam](#output\_bootstrap\_brokers\_iam) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/IAM to the kafka cluster. |
 | <a name="output_bootstrap_brokers_scram"></a> [bootstrap\_brokers\_scram](#output\_bootstrap\_brokers\_scram) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/SCRAM to the kafka cluster. |
+| <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | Amazon Resource Name (ARN) of the MSK cluster |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | MSK Cluster name |
 | <a name="output_config_arn"></a> [config\_arn](#output\_config\_arn) | Amazon Resource Name (ARN) of the configuration |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -29,6 +29,7 @@
 | [aws_msk_cluster.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_configuration) | resource |
 | [aws_msk_scram_secret_association.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_scram_secret_association) | resource |
+| [aws_msk_broker_nodes.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/msk_broker_nodes) | data source |
 
 ## Inputs
 
@@ -97,10 +98,11 @@
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bootstrap_broker_tls"></a> [bootstrap\_broker\_tls](#output\_bootstrap\_broker\_tls) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster |
+| <a name="output_all_brokers"></a> [all\_brokers](#output\_all\_brokers) | A list of all brokers |
 | <a name="output_bootstrap_brokers"></a> [bootstrap\_brokers](#output\_bootstrap\_brokers) | A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster |
 | <a name="output_bootstrap_brokers_iam"></a> [bootstrap\_brokers\_iam](#output\_bootstrap\_brokers\_iam) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/IAM to the kafka cluster. |
 | <a name="output_bootstrap_brokers_scram"></a> [bootstrap\_brokers\_scram](#output\_bootstrap\_brokers\_scram) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/SCRAM to the kafka cluster. |
+| <a name="output_bootstrap_brokers_tls"></a> [bootstrap\_brokers\_tls](#output\_bootstrap\_brokers\_tls) | A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster |
 | <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | Amazon Resource Name (ARN) of the MSK cluster |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | MSK Cluster name |
 | <a name="output_config_arn"></a> [config\_arn](#output\_config\_arn) | Amazon Resource Name (ARN) of the configuration |

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,9 @@ locals {
 }
 
 data "aws_msk_broker_nodes" "default" {
-  cluster_arn = aws_msk_cluster.default[0].arn
+  count = local.enabled ? 1 : 0
+
+  cluster_arn = join("", aws_msk_cluster.default.*.arn)
 }
 
 module "broker_security_group" {

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_msk_scram_secret_association" "default" {
 }
 
 module "hostname" {
-  count = var.zone_id != null ? length(local.brokers) : 0
+  count = var.number_of_broker_nodes > 0 && var.zone_id != null ? var.number_of_broker_nodes : 0
 
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   enabled = module.this.enabled
 
   node_info_list = data.aws_msk_broker_nodes.default.*.node_info_list
-  brokers        = try(flatten(local.node_info_list.*.endpoints), [])
+  brokers        = local.enabled ? flatten(local.node_info_list.*.endpoints) : []
   # If var.storage_autoscaling_max_capacity is not set, don't autoscale past current size
   broker_volume_size_max = coalesce(var.storage_autoscaling_max_capacity, var.broker_volume_size)
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  brokers = flatten(data.aws_msk_broker_nodes.default.node_info_list.*.endpoints)
+  brokers = flatten(data.aws_msk_broker_nodes.default.*.node_info_list.*.endpoints)
   # If var.storage_autoscaling_max_capacity is not set, don't autoscale past current size
   broker_volume_size_max = coalesce(var.storage_autoscaling_max_capacity, var.broker_volume_size)
 

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  bootstrap_brokers               = try(aws_msk_cluster.default[0].bootstrap_brokers, "")
-  bootstrap_brokers_list          = local.bootstrap_brokers != "" ? sort(split(",", local.bootstrap_brokers)) : []
-  bootstrap_brokers_tls           = try(aws_msk_cluster.default[0].bootstrap_brokers_tls, "")
-  bootstrap_brokers_tls_list      = local.bootstrap_brokers_tls != "" ? sort(split(",", local.bootstrap_brokers_tls)) : []
-  bootstrap_brokers_scram         = try(aws_msk_cluster.default[0].bootstrap_brokers_sasl_scram, "")
-  bootstrap_brokers_scram_list    = local.bootstrap_brokers_scram != "" ? sort(split(",", local.bootstrap_brokers_scram)) : []
-  bootstrap_brokers_iam           = try(aws_msk_cluster.default[0].bootstrap_brokers_sasl_iam, "")
-  bootstrap_brokers_iam_list      = local.bootstrap_brokers_iam != "" ? sort(split(",", local.bootstrap_brokers_iam)) : []
-  bootstrap_brokers_combined_list = concat(local.bootstrap_brokers_list, local.bootstrap_brokers_tls_list, local.bootstrap_brokers_scram_list, local.bootstrap_brokers_iam_list)
+  brokers = flatten(data.aws_msk_broker_nodes.default.node_info_list.*.endpoints)
   # If var.storage_autoscaling_max_capacity is not set, don't autoscale past current size
   broker_volume_size_max = coalesce(var.storage_autoscaling_max_capacity, var.broker_volume_size)
 
@@ -58,6 +50,10 @@ locals {
       port    = 2182
     }
   }
+}
+
+data "aws_msk_broker_nodes" "default" {
+  cluster_arn = aws_msk_cluster.default[0].arn
 }
 
 module "broker_security_group" {
@@ -207,7 +203,7 @@ module "hostname" {
   enabled  = module.this.enabled && length(var.zone_id) > 0
   dns_name = "${module.this.name}-broker-${count.index + 1}"
   zone_id  = var.zone_id
-  records  = [split(":", element(local.bootstrap_brokers_combined_list, count.index))[0]]
+  records  = [local.brokers[count.index]]
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  node_info_list = data.aws_msk_broker_nodes.default.*.node_info_list
-  brokers        = local.enabled ? flatten(local.node_info_list.*.endpoints) : []
+  brokers = local.enabled ? flatten(data.aws_msk_broker_nodes.default[0].node_info_list.*.endpoints) : []
   # If var.storage_autoscaling_max_capacity is not set, don't autoscale past current size
   broker_volume_size_max = coalesce(var.storage_autoscaling_max_capacity, var.broker_volume_size)
 
@@ -198,7 +197,7 @@ resource "aws_msk_scram_secret_association" "default" {
 }
 
 module "hostname" {
-  count = var.number_of_broker_nodes > 0 && var.zone_id != null ? var.number_of_broker_nodes : 0
+  count = var.zone_id != null ? length(local.brokers) : 0
 
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 locals {
   enabled = module.this.enabled
 
-  brokers = flatten(data.aws_msk_broker_nodes.default.*.node_info_list.*.endpoints)
+  node_info_list = data.aws_msk_broker_nodes.default.*.node_info_list
+  brokers        = try(flatten(local.node_info_list.*.endpoints), [])
   # If var.storage_autoscaling_max_capacity is not set, don't autoscale past current size
   broker_volume_size_max = coalesce(var.storage_autoscaling_max_capacity, var.broker_volume_size)
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "bootstrap_brokers" {
   value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers)
 }
 
-output "bootstrap_broker_tls" {
+output "bootstrap_brokers_tls" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster"
   value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers_tls)
 }
@@ -21,6 +21,11 @@ output "bootstrap_brokers_scram" {
 output "bootstrap_brokers_iam" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/IAM to the kafka cluster."
   value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers_sasl_iam)
+}
+
+output "all_brokers" {
+  description = "A list of all brokers"
+  value       = local.brokers
 }
 
 output "current_version" {


### PR DESCRIPTION
## what
* Replaced the way the broker hostname records are created.
* Also fixed a typo in the `bootstrap_brokers_tls` output.

## why
Because right now the bootstrap brokers are used to build the hostnames. AWS doesn't give a complete list of brokers in the bootstrap brokers list (see references). So if you have 4 brokers but 3 reported bootstrap brokers then the hostnames for the 4 DNS records are wrong. Also the bootstrap brokers change between refreshes, so the hostnames change with every apply.

## references
* https://docs.aws.amazon.com/msk/1.0/apireference/clusters-clusterarn-bootstrap-brokers.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#bootstrap_brokers