### PR TITLE
Fix security group usage example documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ module "kafka" {
   # security groups to put on the cluster itself
   associated_security_group_ids = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
   # security groups to give access to the cluster
-  associated_security_group_ids = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
+  allowed_security_group_ids = ["sg-XXXXXXXXX", "sg-YYYYYYYY"]
 }
 ```
 


### PR DESCRIPTION
## what

Updating the usage example in the top-level README. It looks like the second instance should be `allowed_security_group_ids` instead of `associated_security_group_ids` again.

## why

I believe the current usage example is incorrect / misleading.

## references

Here's the definition for the `allowed_security_group_ids` variable, which matches up with the comment in the README:
https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/blob/7e6441a123da6e2d521d37e387ace7df86ea1256/security_group_inputs.tf#L11-L18