### PR TITLE
Deprecated ebs_volume_size from upstream aws_msk_cluster

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,8 +185,8 @@ resource "aws_msk_cluster" "default" {
 
   lifecycle {
     ignore_changes = [
-      # Ignore changes to ebs_volume_size in favor of autoscaling policy
-      broker_node_group_info[0].storage_info.ebs_storage_info.volume_size,
+      # Ignore changes to ebs_storage_info in favor of autoscaling policy
+      broker_node_group_info[0].storage_info,
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,11 @@ resource "aws_msk_cluster" "default" {
 
   broker_node_group_info {
     instance_type   = var.broker_instance_type
-    ebs_volume_size = var.broker_volume_size
+    storage_info {
+      ebs_storage_info {
+        volume_size = var.broker_volume_size 
+      }
+    }
     client_subnets  = var.subnet_ids
     security_groups = var.create_security_group ? concat(var.associated_security_group_ids, [module.broker_security_group.id]) : var.associated_security_group_ids
   }
@@ -182,7 +186,7 @@ resource "aws_msk_cluster" "default" {
   lifecycle {
     ignore_changes = [
       # Ignore changes to ebs_volume_size in favor of autoscaling policy
-      broker_node_group_info[0].ebs_volume_size,
+      broker_node_group_info[0].storage_info.ebs_storage_info.volume_size,
     ]
   }
 


### PR DESCRIPTION
## what
* `ebs_volume_size` has been replaced by storage_info in the upstream `aws_msk_cluster.` 
* This leads to validation warnings from terraform.


## why
* Prevent validation warnings.
* Ensure that the module does not end up deprecated in the future.

## references
* [Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster)


