### PR TITLE
brokers_per_zone instead of number_of_broker_nodes

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,6 +16,6 @@ availability_zones = ["us-east-2a", "us-east-2b"]
 
 kafka_version = "2.4.1.1"
 
-number_of_broker_nodes = 4
+broker_per_zone = 2
 
 broker_instance_type = "kafka.t3.small"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -33,13 +33,13 @@ resource "random_id" "config_id" {
 module "kafka" {
   source = "../../"
 
-  zone_id                = var.zone_id
-  security_groups        = [module.vpc.vpc_default_security_group_id]
-  vpc_id                 = module.vpc.vpc_id
-  subnet_ids             = module.subnets.private_subnet_ids
-  kafka_version          = var.kafka_version
-  number_of_broker_nodes = var.number_of_broker_nodes
-  broker_instance_type   = var.broker_instance_type
+  zone_id              = var.zone_id
+  security_groups      = [module.vpc.vpc_default_security_group_id]
+  vpc_id               = module.vpc.vpc_id
+  subnet_ids           = module.subnets.private_subnet_ids
+  kafka_version        = var.kafka_version
+  broker_per_zone      = var.broker_per_zone
+  broker_instance_type = var.broker_instance_type
 
   name = "${module.this.name}${module.this.delimiter}${try(random_id.config_id[0].hex, "")}"
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -18,9 +18,9 @@ variable "broker_instance_type" {
   description = "Specify the instance type to use for the kafka brokers"
 }
 
-variable "number_of_broker_nodes" {
+variable "broker_per_zone" {
   type        = number
-  description = "The desired total number of broker nodes in the kafka cluster. It must be a multiple of the number of specified client subnets."
+  description = "Number of Kafka brokers per zone"
 }
 
 variable "region" {

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_msk_scram_secret_association" "default" {
 }
 
 module "hostname" {
-  count = local.enabled && (var.brokers_per_zone * length(var.subnet_ids)) && var.zone_id != null ? (var.brokers_per_zone * length(var.subnet_ids)) : 0
+  count = local.enabled && var.zone_id != null ? (var.brokers_per_zone * length(var.subnet_ids)) : 0
 
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_msk_cluster" "default" {
   count                  = local.enabled ? 1 : 0
   cluster_name           = module.this.id
   kafka_version          = var.kafka_version
-  number_of_broker_nodes = var.number_of_broker_nodes
+  number_of_broker_nodes = var.brokers_per_zone * length(var.subnet_ids)
   enhanced_monitoring    = var.enhanced_monitoring
 
   broker_node_group_info {
@@ -197,7 +197,7 @@ resource "aws_msk_scram_secret_association" "default" {
 }
 
 module "hostname" {
-  count = local.enabled && var.number_of_broker_nodes > 0 && var.zone_id != null ? var.number_of_broker_nodes : 0
+  count = local.enabled && (var.brokers_per_zone * length(var.subnet_ids)) && var.zone_id != null ? (var.brokers_per_zone * length(var.subnet_ids)) : 0
 
   source  = "cloudposse/route53-cluster-hostname/aws"
   version = "0.12.2"

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "number_of_broker_nodes" {
-  type        = number
-  description = "The desired total number of broker nodes in the kafka cluster. It must be a multiple of the number of specified client subnets."
-}
-
 variable "kafka_version" {
   type        = string
   description = "The desired Kafka software version"
@@ -11,6 +6,16 @@ variable "kafka_version" {
 variable "broker_instance_type" {
   type        = string
   description = "The instance type to use for the Kafka brokers"
+}
+
+variable "broker_per_zone" {
+  type        = number
+  default     = 1
+  description = "Number of Kafka brokers per zone."
+  validation {
+    condition     = length(var.brokers_per_zone) > 0
+    error_message = "The broker_per_zone value must be at atleast 1"
+  }
 }
 
 variable "broker_volume_size" {


### PR DESCRIPTION
## What
- Replace variable **number_of_broker_nodes** with **broker_per_zone**
- Default **broker_per_zone** as 1

## Why
- instead of relying on the input being a multiple of the subnets we can calculate the number_of_broker_nodes by multiplying the desired number of brokers per zone per subnets
- this behaviour is similar to the AWS Console UI approach (custom method) that requires the number of brokers per zone and subnets
- number of brokers per zone is a more understandable variable than number of broker of nodes
