### PR TITLE
Add jmx exporter & node_exporter security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,20 @@ locals {
       enabled = true
       port    = 2182
     }
+    # The following two protocols are enabled on demand of user
+    # See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#jmx_exporter
+    # and https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#node_exporter
+    # and https://docs.aws.amazon.com/msk/latest/developerguide/open-monitoring.html#set-up-prometheus-host
+    jmx_exporter = {
+      name    = "JMX Exporter"
+      enabled = var.jmx_exporter_enabled
+      port    = 11001
+    }
+    node_exporter = {
+      name    = "Node Exporter"
+      enabled = var.node_exporter_enabled
+      port    = 11002
+    }
   }
 }
 


### PR DESCRIPTION
## what
* Add JMX Exporter protocol to locals.protocols.
* Add Node Exporter protocol to locals.protocols.

## why
* JMX Exporter should be accessible through the security group created to access the brokers
* Node Exporter should be accessible through the security group created to access the brokers

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#jmx_exporter
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#node_exporter
* https://docs.aws.amazon.com/msk/latest/developerguide/open-monitoring.html#set-up-prometheus-host

