### PR TITLE
Wastebasket/fix ebs volume size deprecation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,11 @@ resource "aws_msk_cluster" "default" {
 
   broker_node_group_info {
     instance_type   = var.broker_instance_type
-    ebs_volume_size = var.broker_volume_size
+    storage_info {
+      ebs_storage_info {
+        volume_size = var.broker_volume_size
+      }
+    }
     client_subnets  = var.subnet_ids
     security_groups = var.create_security_group ? concat(var.associated_security_group_ids, [module.broker_security_group.id]) : var.associated_security_group_ids
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.15.0"
     }
   }
 }


### PR DESCRIPTION
## what
* change `ebs_volume_size` to `storage_info.ebs_storage_info.volume_size`
* lock terraform version to `>= 4.15.0`

## why
* `ebs_volume_size` is deprecated in `4.15.0` https://registry.terraform.io/providers/hashicorp/aws/4.15.0/docs/resources/msk_cluster#ebs_volume_size

## references
* https://registry.terraform.io/providers/hashicorp/aws/4.15.0/docs/resources/msk_cluster#ebs_volume_size

