### PR TITLE
Public Access flag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,11 @@ resource "aws_msk_cluster" "default" {
     ebs_volume_size = var.broker_volume_size
     client_subnets  = var.subnet_ids
     security_groups = var.create_security_group ? concat(var.associated_security_group_ids, [module.broker_security_group.id]) : var.associated_security_group_ids
+    connectivity_info {
+      public_access {
+        type = var.public_access ? "SERVICE_PROVIDED_EIPS" : "DISABLED"
+      }
+    }  
   }
 
   configuration_info {

--- a/variables.tf
+++ b/variables.tf
@@ -196,3 +196,9 @@ variable "storage_autoscaling_disable_scale_in" {
   default     = false
   description = "If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource."
 }
+
+variable "public_access" {
+  type        = bool
+  default     = false
+  description = "Enable public access to MSK cluster (given that all of the requirements are met)"
+}


### PR DESCRIPTION
## what
Allows to enable Public Access on MSK cluster

## why
There are cases when you want it. Recently `aws_cluster` module was updated to allow that, forwarding this flag to this module to make life easier

