### PR TITLE
updating README for 1.1.1 - broker_per_zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ module "kafka" {
   zone_id                = "Z14EN2YD427LRQ"
   subnet_ids             = ["subnet-XXXXXXXXX", "subnet-YYYYYYYY"]
   kafka_version          = "2.4.1"
-  number_of_broker_nodes = 2 # this has to be a multiple of the # of subnet_ids
+  broker_per_zone        = 2 # this has to be a multiple of the # of subnet_ids
   broker_instance_type   = "kafka.m5.large"
 
   # security groups to put on the cluster itself


### PR DESCRIPTION
## what
* updating README for 1.1.1 - broker_per_zone

## why
* it is confusing during we are updating the module version from 0.8.x to 1.X.X 

## references
* a simple readme update https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/commit/b61057e482ac69f33e6ad99363c91911a1d4068d

