### PR TITLE
Remove ebs_volume_size due deprecation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,7 +127,11 @@ resource "aws_msk_cluster" "default" {
 
   broker_node_group_info {
     instance_type   = var.broker_instance_type
-    ebs_volume_size = var.broker_volume_size
+    storage_info {
+      ebs_storage_info {
+        volume_size = var.broker_volume_size
+      }
+    }
     client_subnets  = var.subnet_ids
     security_groups = var.create_security_group ? concat(var.associated_security_group_ids, [module.broker_security_group.id]) : var.associated_security_group_ids
   }


### PR DESCRIPTION
## what
* ebs_volume_size was deprecated 
* [ebs_volume_size](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#ebs_volume_size) - (Optional, Deprecated use storage_info.ebs_storage_info.volume_size instead) The size in GiB of the EBS volume for the data drive on each broker node.

## why
* When you are consuming this module in its latest version is showing the following error
```
│ Warning: Deprecated attribute
│ 
│   on .terraform/modules/msk/main.tf line 200, in resource "aws_msk_cluster" "default":
│  200:       broker_node_group_info[0].ebs_volume_size,
│ 
```
* It's very likely that the people using this module are setting the size of their brokers to the default value

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster#ebs_volume_size 

