### PR TITLE
Make scram secret assocation optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,7 +205,7 @@ resource "aws_msk_cluster" "default" {
 }
 
 resource "aws_msk_scram_secret_association" "default" {
-  count = local.enabled && var.client_sasl_scram_enabled ? 1 : 0
+  count = local.enabled && var.client_sasl_scram_enabled && var.client_sasl_scram_secret_association_enabled ? 1 : 0
 
   cluster_arn     = aws_msk_cluster.default[0].arn
   secret_arn_list = var.client_sasl_scram_secret_association_arns

--- a/variables.tf
+++ b/variables.tf
@@ -95,6 +95,12 @@ variable "client_sasl_scram_enabled" {
   description = "Enables SCRAM client authentication via AWS Secrets Manager (cannot be set to `true` at the same time as `client_tls_auth_enabled`)."
 }
 
+variable "client_sasl_scram_secret_association_enabled" {
+  type = bool
+  default = true
+  description = "Enables the list of AWS Secrets Manager secret ARNs for scram authentication"
+}
+
 variable "client_sasl_scram_secret_association_arns" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## what
* Make the `aws_msk_scram_secret_association` resource optional when sasl/scram authentication is enabled through a new variable `client_sasl_scram_secret_association_enabled`
* The default behaviour is the same as before

## why
* The `aws_msk_scram_secret_association` resource is not very flexible and in certain use cases the preference is to manage the secret associations out of band from the cluster creation
* In our case we need to enable sasl/scram at the point of creating the cluster of the cluster, but need to manage sasl/scram users in another tf root
* Having `aws_msk_scram_secret_association` resources in separate roots creates conflicts where they will constantly overwrite each others changes

## references
* See https://github.com/hashicorp/terraform-provider-aws/issues/16791

