### PR TITLE
Update splat msk cluster ebs volume size

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,26 +1,26 @@
 output "cluster_arn" {
   description = "Amazon Resource Name (ARN) of the MSK cluster"
-  value       = join("", aws_msk_cluster.default.*.arn)
+  value       = join("", aws_msk_cluster.default[*].arn)
 }
 
 output "bootstrap_brokers" {
   description = "A comma separated list of one or more hostname:port pairs of kafka brokers suitable to boostrap connectivity to the kafka cluster"
-  value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers)
+  value       = join(",", aws_msk_cluster.default[*].bootstrap_brokers)
 }
 
 output "bootstrap_brokers_tls" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity to the kafka cluster"
-  value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers_tls)
+  value       = join(",", aws_msk_cluster.default[*].bootstrap_brokers_tls)
 }
 
 output "bootstrap_brokers_scram" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/SCRAM to the kafka cluster."
-  value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers_sasl_scram)
+  value       = join(",", aws_msk_cluster.default[*].bootstrap_brokers_sasl_scram)
 }
 
 output "bootstrap_brokers_iam" {
   description = "A comma separated list of one or more DNS names (or IPs) and TLS port pairs kafka brokers suitable to boostrap connectivity using SASL/IAM to the kafka cluster."
-  value       = join(",", aws_msk_cluster.default.*.bootstrap_brokers_sasl_iam)
+  value       = join(",", aws_msk_cluster.default[*].bootstrap_brokers_sasl_iam)
 }
 
 output "all_brokers" {
@@ -30,32 +30,32 @@ output "all_brokers" {
 
 output "current_version" {
   description = "Current version of the MSK Cluster used for updates"
-  value       = join("", aws_msk_cluster.default.*.current_version)
+  value       = join("", aws_msk_cluster.default[*].current_version)
 }
 
 output "zookeeper_connect_string" {
   description = "A comma separated list of one or more hostname:port pairs to use to connect to the Apache Zookeeper cluster"
-  value       = join(",", aws_msk_cluster.default.*.zookeeper_connect_string)
+  value       = join(",", aws_msk_cluster.default[*].zookeeper_connect_string)
 }
 
 output "config_arn" {
   description = "Amazon Resource Name (ARN) of the configuration"
-  value       = join("", aws_msk_configuration.config.*.arn)
+  value       = join("", aws_msk_configuration.config[*].arn)
 }
 
 output "latest_revision" {
   description = "Latest revision of the configuration"
-  value       = join("", aws_msk_configuration.config.*.latest_revision)
+  value       = join("", aws_msk_configuration.config[*].latest_revision)
 }
 
 output "hostname" {
   description = "Comma separated list of one or more MSK Cluster Broker DNS hostname"
-  value       = join(",", module.hostname.*.hostname)
+  value       = join(",", module.hostname[*].hostname)
 }
 
 output "cluster_name" {
   description = "MSK Cluster name"
-  value       = join("", aws_msk_cluster.default.*.cluster_name)
+  value       = join("", aws_msk_cluster.default[*].cluster_name)
 }
 
 output "security_group_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 4.15"
     }
   }
 }


### PR DESCRIPTION
## what
- update splat operators
- update aws resource syntax in msk cluster for ebs_volume_size and related aws provider versioning

## why
- post-terraform 0.12.0 splat format
- reduce tflint, terraform validate noise
- ebs_volume_size was deprecated from aws_msk_cluster

## references
- https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_deprecated_index.md
- https://registry.terraform.io/providers/hashicorp/aws/4.15.0/docs/resources/msk_cluster#ebs_volume_size

