### PR TITLE
Facilitate error-free MSK upgrades

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,10 +109,14 @@ module "broker_security_group" {
 resource "aws_msk_configuration" "config" {
   count          = local.enabled ? 1 : 0
   kafka_versions = [var.kafka_version]
-  name           = module.this.id
+  name           = join("-",[module.this.id,replace(var.kafka_version,".","-")])
   description    = "Manages an Amazon Managed Streaming for Kafka configuration"
 
   server_properties = join("\n", [for k in keys(var.properties) : format("%s = %s", k, var.properties[k])])
+    
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_msk_cluster" "default" {


### PR DESCRIPTION
## what

This change adds support for MSK upgrades.

## why

Necessary to support MSK upgrades, rather than destroying and recreating the cluster (which was previously the case).

## references
