### PR TITLE
Fix issues with dynamic ClientAuthentication block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -219,6 +219,8 @@ resource "aws_msk_cluster" "default" {
     ignore_changes = [
       # Ignore changes to ebs_volume_size in favor of autoscaling policy
       broker_node_group_info[0].storage_info[0].ebs_storage_info[0].volume_size,
+      # Ignore changes to avoid issues like https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/issues/52
+      client_authentication,
     ]
   }
 


### PR DESCRIPTION
## what

Fix for issues with cluster config edit (terraform always wants to change `client_authentication` config as follows)

## why
  ```# module.msk.aws_msk_cluster.default[0] will be updated in-place
  ~ resource "aws_msk_cluster" "default" {
        id                           = "arn:aws:kafka:eu-central-1:0000000:cluster/kafka/"
        # (12 unchanged attributes hidden)

      ~ client_authentication {
            # (1 unchanged attribute hidden)

          - tls {}

            # (1 unchanged block hidden)
        }

        # (5 unchanged blocks hidden)
    }
```

This leads to following error:

```
 Error: updating MSK Cluster (arn:aws:kafka:eu-central-1:00000:cluster/kafka/) security: BadRequestException: The request does not include any updates to the security setting of the cluster. Verify the request, then try again.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "1d43c33f-6f0e-4ad7-b25f-17130137ccd2"
│   },
│   Message_: "The request does not include any updates to the security setting of the cluster. Verify the request, then try again."
│ }
```

## references
This issue is almost like https://github.com/cloudposse/terraform-aws-msk-apache-kafka-cluster/issues/52
