### PR TITLE
Add VPC Connectivity SASL Scram and IAM

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,6 +152,14 @@ resource "aws_msk_cluster" "default" {
       public_access {
         type = var.public_access_enabled ? "SERVICE_PROVIDED_EIPS" : "DISABLED"
       }
+      vpc_connectivity {
+        client_authentication {
+          sasl {
+            iam = var.vpc_connectivity_client_authentication_sasl_iam_enabled 
+            scram = var.vpc_connectivity_client_authentication_sasl_scram_enabled
+          }          
+        } 
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -247,3 +247,17 @@ variable "public_access_enabled" {
   description = "Enable public access to MSK cluster (given that all of the requirements are met)"
   nullable    = false
 }
+
+variable "vpc_connectivity_client_authentication_sasl_iam_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Enables SASL/IAM authentication for VPC connectivity"
+  nullable    = false
+}
+
+variable "vpc_connectivity_client_authentication_sasl_scram_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Enables SASL/SCRAM authentication for VPC connectivity."
+  nullable    = false
+}


### PR DESCRIPTION
## what

<!--

- Added support for VPC connectivity client authentication using SASL/IAM and SASL/SCRAM.
- Updated resource configuration to include the necessary properties for enabling VPC connectivity client authentication IAM and SCRAM.
- Added variables to configure VPC connectivity client authentication IAM and SCRAM. 
- Updated module documentation to include the new VPC connectivity client authentication configuration options.
-->

## why

<!--
- This module does not currently support configuration VPC connectivity for private link functionality. 
- This enhancement provides ability to configure VPC connectivity and enables the usage of private link. 
-->

## references

<!--
- AWS Access Across VPC Documentation --> https://docs.aws.amazon.com/msk/latest/developerguide/aws-access-mult-vpc.html
-->
