### PR TITLE
feat: allow overriding default Terraform operation timeouts using 'tf_operation_timeouts' variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -239,6 +239,12 @@ resource "aws_msk_cluster" "default" {
     ]
   }
 
+  timeouts {
+    create = lookup(var.tf_operation_timeouts, "create", "2h")
+    update = lookup(var.tf_operation_timeouts, "update", "2h")
+    delete = lookup(var.tf_operation_timeouts, "delete", "2h")
+  }
+
   tags = module.this.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,9 @@ variable "public_access_enabled" {
   description = "Enable public access to MSK cluster (given that all of the requirements are met)"
   nullable    = false
 }
+
+variable "tf_operation_timeouts" {
+  type        = map(string)
+  default     = {}
+  description = "Optional MSK cluster operation timeouts. Keys: 'create', 'update', 'delete'. Durations like '3h', '2h30m'. Unset keys use provider defaults."
+}


### PR DESCRIPTION
## what

Add option to override default Terraform operation timeouts for aws_msk_cluster module

## why

There are operations that take long time to be applied to the kafka cluster, examples are:
- broker instance type change
- broker count change
- kafka version upgrades
It will be useful to have a way to extend relatively short default time (2h) to more realistic values for large clusters operation times.

## references
