### PR TITLE
fix: adds missing multi-vpc broker string outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,21 @@ output "bootstrap_brokers_public_sasl_iam" {
   description = "Comma separated list of one or more DNS names (or IP addresses) and SASL IAM port pairs for public access to the Kafka cluster using SASL/IAM"
 }
 
+output "bootstrap_brokers_vpc_connectivity_sasl_iam" {
+  value       = one(aws_msk_cluster.default[*].bootstrap_brokers_vpc_connectivity_sasl_iam)
+  description = "Comma separated list of one or more DNS names (or IP addresses) and SASL IAM port pairs for access to the Kafka cluster using Multi-VPC SASL/IAM"
+}
+
+output "bootstrap_brokers_vpc_connectivity_sasl_scram" {
+  value       = one(aws_msk_cluster.default[*].bootstrap_brokers_vpc_connectivity_sasl_scram)
+  description = "Comma separated list of one or more DNS names (or IP addresses) and SASL SCRAM port pairs for access to the Kafka cluster using Multi-VPC SASL/SCRAM"
+}
+
+output "bootstrap_brokers_vpc_connectivity_tls" {
+  value       = one(aws_msk_cluster.default[*].bootstrap_brokers_vpc_connectivity_tls)
+  description = "Comma separated list of one or more DNS names (or IP addresses) and TLS port pairs for access to the Kafka cluster using Multi-VPC TLS"
+}
+
 output "zookeeper_connect_string" {
   value       = one(aws_msk_cluster.default[*].zookeeper_connect_string)
   description = "Comma separated list of one or more hostname:port pairs to connect to the Apache Zookeeper cluster"


### PR DESCRIPTION
## what

- fix: adds broker string outputs for multi-vpc enabled clusters

## why

- missed in initial multi-vpc implementation
- terraform in client vpcs should be able to read multi-vpc broker strings via remote-state

## references

- fixes #136
